### PR TITLE
Changes regarding new certificates

### DIFF
--- a/PushSharp.Apple/ApplePushChannelSettings.cs
+++ b/PushSharp.Apple/ApplePushChannelSettings.cs
@@ -102,7 +102,7 @@ namespace PushSharp.Apple
 				if (!issuerName.Contains("Apple"))
 					throw new ArgumentException("Your Certificate does not appear to be issued by Apple!  Please check to ensure you have the correct certificate!");
 
-				if (production && !subjectName.Contains("Apple Production IOS Push Services"))
+				if (production && !subjectName.Contains("Apple Production IOS Push Services") && !subjectName.Contains("Apple Push Services"))
 					throw new ArgumentException("You have selected the Production server, yet your Certificate does not appear to be the Production certificate!  Please check to ensure you have the correct certificate!");
 
 


### PR DESCRIPTION
Compatibility with update https://developer.apple.com/news/?id=12172015b.
Production certificate type name has been changed to "Apple Push Services".
